### PR TITLE
修正部分元素语义结构

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,26 +105,7 @@
                     transform: scale(103%);
                     position: relative;
                 }
-                .a:hover::after{
-                    content: '\e71b\0020\0020 链接';
-                    pointer-events: none;
-                    opacity: .6;
-                    position: absolute;
-                    font-size: smaller !important;
-                    font-weight: lighter;
-                    display: block;
-                    transform: scale(47%);
-                    width: fit-content;
-                    background-color: #000000a7;
-                    mix-blend-mode: difference;
-                    box-shadow: 1px 1px 1px rgb(35, 35, 35);
-                    top: -1.19rem;
-                    right: -1.98rem;
-                    padding: 3px 6px;
-                    border-radius: 15%;
-                    animation: .5s cubic-bezier(0.075, 0.82, 0.165, 1) forwards fain;
-                    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif, 'fluent-icon';
-                }
+                
                 .a:active {
                     color: #f5d666;
                     transform: scale(97%);

--- a/src/components/FailureComponent.vue
+++ b/src/components/FailureComponent.vue
@@ -18,10 +18,10 @@ function refresh(){
 <template>
     <div class="w-full fade-in p-2 rounded-lg bg-zinc-200 bg-opacity-70 dark:bg-opacity-10 scale-90 hover:scale-95 group transition shadow grid justify-items-center items-center">
         <div class="grid gap-2">
-            <p class="text-center group-hover:scale-105 scale-100 transition">
+            <div class="text-center group-hover:scale-105 scale-100 transition">
                 {{ t('base.failed') }}
                 <p :class="props.message == undefined ? 'hidden' : ''">{{ props.message ?? '' }}</p>
-            </p>
+            </div>
             <div>
                 <Pressable :isFuncButton="true" :noStartIcon="true" @click.native="refresh()">
                     {{ t('base.retry') }}

--- a/src/langs/zh_hans.ts
+++ b/src/langs/zh_hans.ts
@@ -301,6 +301,9 @@ export const zhHans = {
     LauncherX: {
         intro: '强大、优雅、美观。使用开源核心',
         nowDownload: '立即下载',
+        failedHint1: "获取失败了! ",
+        failedHint2: "点击直接下载LauncherX",
+        failedHint3: "<br>这个文件可能不会定期更新! 只是应急出现在了这里. <br>如果你急需其他构建的LauncherX, 请参考下方联系我们.",
         downIntro1: '文件可能不会随着构建管线及时更新。',
         downIntro2: '前往主站',
         downIntro3: '获取最新版本，或者下载后使用',

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -75,7 +75,7 @@
                 {{ t('about.morePage2') }}<a class="text-blue-400 mx-0.5 hover:text-blue-500 active:text-blue-700 transition no-underline hover:underline active:underline" href="https://corona.studio">https://corona.studio</a>{{ t('about.morePage3') }}
             </p>
             <h2 class="title-str pt-1 translate-y-1.5">{{ t('about.aboutUs') }}</h2>
-            <p class="text-xl  break">
+            <div class="text-xl  break">
                 <div class="pl-0 lg:pl-5  translate-y-2.5 ">
                     <span class="lg:mt-3 mt-2  font-semibold text-4xl  inline-block">
                         <div class="title-str title-str-reverse title-str-flur scale-105   : invert dark:text-zinc-900 text-zinc-100" >
@@ -110,7 +110,7 @@
                     ...
                 </span>
                 
-            </p>
+            </div>
             <h2 class="title-str pt-1">{{ t('about.intro8') }}</h2>
             <div class="bg-zinc-100 dark:bg-zinc-800 bg-opacity-70 p-1.5 m-0.5 my-2 mb-0 translate-y-1 rounded-xl">
                 <div class="grid grid-cols-1 lg:grid-cols-3 gap-1.5 justify-center rounded-lg px-1 mb-3">

--- a/src/pages/CMF.vue
+++ b/src/pages/CMF.vue
@@ -55,7 +55,7 @@
         CMF-CoronaStudio
     </PageTitle>
     <div id="CMFTOP" class="? pt-3.5 container?  mx-auto grid justify-center justify-items-center items-center p-1.5 lg:p-3 w-11/12 sm:w-5/6 lg:w-9/12">
-        <p>
+        <div>
             <img src="/img/icons/cmflogo.webp" alt="" class="mx-auto w-1/2 sm:w-1/3 md:w-1/4 lg:w-1/5 xl:w-1/6  mt-12 fade-in " > <br>
             <h1 class="text-3xl font-semibold text-yellow-500">{{ t('cmf.begin') }}</h1>
             <h5 class="text-lg">
@@ -71,7 +71,7 @@
                 {{ t('cmf.linkIntro1') }} &#xe8c8; {{ t('cmf.linkIntro2') }} &#xe71b; {{ t('cmf.linkIntro3') }} <span class=" font-semibold font-sans">?</span> {{ t('cmf.linkIntro4') }}
             </h5>
 
-        </p>
+        </div>
         <div class="w-judge mx-auto bg-zinc-200 dark:bg-zinc-800 bg-opacity-80 dark:bg-opacity-80 mt-3 rounded-lg transition p-1.5 lg:p-3 xl:p-5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2.5 lg:gap-3.5 xl:gap-5" id="CMFS">
             <h6 v-if="!serverList" class="grid justify-items-center justify-center items-center col-span-full text-center text-xl p-3 m-1" >
               <div class="">

--- a/src/pages/LauncherX.vue
+++ b/src/pages/LauncherX.vue
@@ -334,7 +334,7 @@ onMounted(async () => {
                                         :no-start-icon="true"
                                         v-for="down of downloads"
                                         :key="down.build"
-                                        :class="`py-2 my-1  ${down.match ? 'shining-eternal' : ''}`"
+                                        :class="`py-2 my-1 text-sm  ${down.match ? 'shining-eternal' : ''}`"
                                         :type="`download:LauncherX-${down.build}@${down.build}.zip`"
                                         :link="
                                             runLinkFilter(down.link, `download:LauncherX-${down.build}@${down.build}.zip`)
@@ -359,7 +359,14 @@ onMounted(async () => {
                                 </div>         
                                 <div class="col-span-full scale-95" v-if="isFailed">
                                     <FailureComponent  class="" />  
-                                    <p class="text-sm mt-1">获取失败了! <a href="https://v2.csmin.kami.su/products/lx/LauncherX_20240311_net8.0-windows_win-x64.zip" download="LauncherX.Avalonia.x64.zip" class="a">点击直接下载LauncherX</a><br>这个文件可能不会定期更新! 只是应急出现在了这里. <br>如果你急需其他构建的LauncherX, 请参考下方联系我们.</p>
+                                    <p class="text-sm mt-1">
+                                        {{ t("LauncherX.failedHint1") }}
+                                        <a href="https://v2.csmin.kami.su/products/lx/LauncherX_20240311_net8.0-windows_win-x64.zip" download="LauncherX.Avalonia.x64.zip" class="a">
+                                            <span v-html="t('LauncherX.failedHint2')"></span>
+                                        </a>
+                                        <span v-html="t('LauncherX.failedHint3')"></span>
+                                        
+                                    </p>
                                 </div>                     
                                 <p
                                     class="col-span-full text-center mb-2 mt-6 font-bold">


### PR DESCRIPTION
还添加了i18n条目

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the user interface by replacing `<p>` tags with `<div>` tags for better structure and styling, and it adds new failure hints in the `zh_hans.ts` file for improved user feedback during download failures.

### Detailed summary
- Added new failure hints in `zh_hans.ts`:
  - `failedHint1`: "获取失败了! "
  - `failedHint2`: "点击直接下载LauncherX"
  - `failedHint3`: "这个文件可能不会定期更新! 只是应急出现在了这里. 如果你急需其他构建的LauncherX, 请参考下方联系我们."
- Replaced `<p>` tags with `<div>` tags in:
  - `FailureComponent.vue`
  - `About.vue`
  - `CMF.vue`
  - `LauncherX.vue`
- Adjusted class names for better styling in `LauncherX.vue`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->